### PR TITLE
LineContents: add line2fbf

### DIFF
--- a/l0/ASSFoundation/Tag/ClipRect.moon
+++ b/l0/ASSFoundation/Tag/ClipRect.moon
@@ -34,6 +34,7 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
     c = a\copy!
     c.topLeft = a.topLeft\lerp b.topLeft, t
     c.bottomRight = a.bottomRight\lerp b.bottomRight, t
+    return c
 
   ClipRect.setInverse = (state = true) =>
     @__tag.inverse = state

--- a/l0/ASSFoundation/Tag/Color.moon
+++ b/l0/ASSFoundation/Tag/Color.moon
@@ -31,4 +31,12 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
       hb, sb, vb = b\getHSV!
       return ha + (hb - ha)*t, sa + (sb - sa)*t, va + (vb - va)*t
 
+  Color.lerpRGB = (a, b, t) ->
+    c = a\copy!
+    ba, ga, ra = a\getTagParams!
+    bb, gb, rb = b\getTagParams!
+    with c
+      .r.value, .g.value, .b.value = ra + (rb - ra)*t, ga + (gb - ga)*t, ba + (bb - ba)*t
+    return c
+
   return Color

--- a/l0/ASSFoundation/Tag/Fade.moon
+++ b/l0/ASSFoundation/Tag/Fade.moon
@@ -38,6 +38,34 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
     @checkPositive inDuration, outDuration
     return @inAlpha\getTagParams!, @midAlpha\getTagParams!, @outAlpha\getTagParams!, t1, math.max(t2, t1), t3, math.max(t4, t3)
 
+  --- Interpolate the fade for any given time
+  -- @param time time at which fade must be interpolated of
+  -- @param lineDuration duration of the current line
+  -- @param alpha alpha in the first tag block if it exists
+  -- @return the interpolated alpha value
+  Fade.interpolate = (time, lineDuration, alpha) =>
+    local a1, a2, a3, t1, t2, t3 , t4, finalAlpha
+    if @__tag.name == "fade_simple"
+      a1, a2, a3, t1, t4  = 255, 0, 255, 0, lineDuration
+      t2, t3 = @inDuration\getTagParams!, @outDuration\getTagParams!
+      t3 = t4 - t3
+    else
+      a1, a2, a3, t1, t2, t3 , t4 = @getTagParams!
+
+    a2 = alpha if alpha
+    currAlpha = a3
+    if time < t1
+      currAlpha = a1
+    elseif time < t2
+      cf = (time - t1)/(t2 - t1)
+      currAlpha = a1 * (1 - cf) + a2 * cf
+    elseif time < t3
+      currAlpha = a2
+    elseif time < t4
+      cf = (time - t3)/(t4 - t3)
+      currAlpha = a2 * (1 - cf)+ a3 * cf
+    return currAlpha
+
   -- TODO: add method to convert between fades by supplying a line duration
 
   return Fade


### PR DESCRIPTION
fixes #5

This PR adds a new method to split lines to frames. Supports for move, transforms and fade. Returns a list of lines.

Additionally adds a method to lerp fade value and return alpha and lerp colors in RGB colorspace(it would only lerp using HSV earlier). Also fixes lerp for rectangular clips.

You could do something like this to convert line2fbf in your script.

```moonscript
main = (sub, sel) ->
  lines = LineCollection sub, sel
  toDelete = {}
  lines\runCallback ((lines, line, i) ->
    data = ASS\parse line
    fbf = data\line2fbf!
    lines\addLine split for split in *[line for line in *fbf]
    toDelete[#toDelete+1] = line
  ), true
  lines\insertLines!
  lines\deleteLines toDelete
```
 The code above only converts the line to fbf but if you desire, you could also loop through each line the method returns and do your own stuff before inserting the line to subtitle.