### PR TITLE
Fix a few issues with parsing drawings

### DIFF
--- a/l0/ASSFoundation/Draw/Bezier.moon
+++ b/l0/ASSFoundation/Draw/Bezier.moon
@@ -47,7 +47,13 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
 
   DrawBezier.getTagParams = (precision = @__tag.precision) =>
     x1, y1, x2, y2, x3, y3 = @p1.x, @p1.y, @p2.x, @p2.y, @p3.x, @p3.y
-    x1, x2, x3, y1, y2, y3 %= @__tag.mod if @__tag.mod
+    if @__tag.mod
+      x1 %= @__tag.mod
+      x2 %= @__tag.mod
+      x2 %= @__tag.mod
+      y1 %= @__tag.mod
+      y2 %= @__tag.mod
+      y2 %= @__tag.mod
 
     return round(x1, precision), round(y1, precision), round(x2, precision), round(y2, precision), round(x3, precision), round(y3, precision)
 

--- a/l0/ASSFoundation/Parser/Drawing.moon
+++ b/l0/ASSFoundation/Parser/Drawing.moon
@@ -38,7 +38,7 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
 
         -- close command closes a contour
         if cmdType == Close
-          contour[d] = Close!
+          contour[d] = Close {}
 
         -- There are two ways for a new drawing command to start
         -- (a) a new command is explicitely denoted by its identifier m, l, b, etc

--- a/l0/ASSFoundation/Parser/Drawing.moon
+++ b/l0/ASSFoundation/Parser/Drawing.moon
@@ -103,13 +103,15 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
                   junk\append prm, " "
                   -- make sure to read another parameter for this command
                   -- to replace the one we just gave up
-                  skippedOrdCnt, prmCnt += 1
+                  skippedOrdCnt += 1
+                  prmCnt += 1
                 else
                   -- move junk trailing the y ordinate into a comment section
                   prms[p-skippedOrdCnt] = tonumber ord
                   if not prms[p-skippedOrdCnt]
                     junk\append prm, " "
-                    skippedOrdCnt, prmCnt += 1
+                    skippedOrdCnt += 1
+                    prmCnt += 1
                   else junk\append fragment, " "
                 p += 1
 

--- a/l0/ASSFoundation/Primitive/Point.moon
+++ b/l0/ASSFoundation/Primitive/Point.moon
@@ -25,7 +25,9 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
 
   Point.getTagParams = (precision = @__tag.precision) =>
     x, y = @x, @y
-    x, y %= @__tag.mod if @__tag.mod
+    if @__tag.mod
+      x %= @__tag.mod
+      y %= @__tag.mod
 
     return round(x, precision), round(y, precision)
 


### PR DESCRIPTION
This can mostly be reviewed commit by commit, with explanations in the commit messages.
The handling of the `c` command isn't perfect yet, especially since it should only be relevant when following `s` commands, and those aren't even recognized yet. For that reason, I just made this minimally invasive fix and nothing more. If parsing of `s` is ever added, `c` can be adjusted.