### PR TITLE
Allow repeating the command between parameters 

### DIFF
--- a/l0/ASSFoundation/Parser/Drawing.moon
+++ b/l0/ASSFoundation/Parser/Drawing.moon
@@ -58,6 +58,13 @@ return (ASS, ASSFInst, yutilsMissingMsg, createASSClass, Functional, LineCollect
               p += 1
               continue
 
+            -- skip repeats of the same drawing command after ordinate pairs
+            if (p - skippedOrdCnt) % 2 == 1 and cmdMap[prm] == prevCmdType
+              p += 1
+              skippedOrdCnt += 1
+              prmCnt += 1
+              continue
+
             -- process ordinates that failed to cast to a number
 
             -- either the command or the the drawing is truncated


### PR DESCRIPTION
Originally part of #9, but made a separate PR because it changes parsing logic.

Drawing strings like `b 0 0 100 200 300 400` internally translate to something like `b 0 0 b 100 200 b 300 400` on both libass and xy-VSFilter, so the latter string will have the same effect. But upon encountering `b 0 0 b 100 200 300 400`, ASSFoundation will error out with a message like "incorrect number of ordinates for command 'b': expected 6, got 2".

This commit skips repetitions of the currently active drawing commands in parameters. The code only triggers after encountering parameters to commands that wouldn't cast to numbers, so it shouldn't change parsing for drawing strings that assf previously considered valid. Still, it can change behavior when encountering "invalid" drawings.