### PR TITLE
ASSFoundation: toFriendlyName and toTagName should accept both types of name as input

### DIFF
--- a/l0/ASSFoundation.moon
+++ b/l0/ASSFoundation.moon
@@ -611,6 +611,7 @@ for name, tag in pairs ASS.tagMap
   -- populate friendly name <-> tag name conversion tables
   if tag.friendlyName
     ASS.toFriendlyName[name], ASS.toTagName[tag.friendlyName] = tag.friendlyName, name
+    ASS.toFriendlyName[tag.friendlyName], ASS.toTagName[name] = tag.friendlyName, name
   -- fill tag names table
   tagType = ASS.tagNames[tag.type]
   if not tagType


### PR DESCRIPTION
***Previous behaviour:***  
`ASS.toFriendlyName` will return the friendly name if it is fed with tag name.  
However, it will return `nil` if it is fed with friendly name.  

***Requested behaviour:***  
`ASS.toFriendlyName` accepts both tag name and friendly name and will always return the corresponding friendly name.  

The same (opposite, I mean) applies to `ASS.toTagName`.  

Thank you!  